### PR TITLE
Configure logger via CLI args

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -1,17 +1,27 @@
 import logging
 
+DEFAULT_LOG_FILE = "debug.log"
+
 logger = logging.getLogger('kemono-dl')
 
 
-def configure_logger(args: dict) -> None:
-    """Configure logging using already parsed arguments."""
+def configure_logger(args: dict, log_file: str = DEFAULT_LOG_FILE) -> None:
+    """Configure logging using already parsed arguments.
+
+    Parameters
+    ----------
+    args : dict
+        Parsed command-line arguments.
+    log_file : str, optional
+        Name of the verbose log file. Defaults to :data:`DEFAULT_LOG_FILE`.
+    """
 
     # Remove any existing handlers to avoid duplicate logs when reconfigured
     logger.handlers.clear()
 
     if args.get('verbose'):
         # clear log file
-        with open('debug.log', 'w'):
+        with open(log_file, 'w'):
             pass
 
     logging.getLogger("requests").setLevel(logging.WARNING)
@@ -27,7 +37,7 @@ def configure_logger(args: dict) -> None:
     stream_format = logging.Formatter('%(levelname)s:%(message)s')
 
     if args.get('verbose'):
-        file_handler = logging.FileHandler('debug.log', encoding="utf-16")
+        file_handler = logging.FileHandler(log_file, encoding="utf-16")
         file_handler.setFormatter(file_format)
         logger.addHandler(file_handler)
 

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,34 +1,36 @@
 import logging
 
-from .args import get_args
-
-args = get_args()
-
-if args['verbose']:
-    # clear log file
-    file = open('debug.log','w')
-    file.close()
-
-logging.getLogger("requests").setLevel(logging.WARNING)
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-
 logger = logging.getLogger('kemono-dl')
 
-logger.setLevel(logging.INFO)
-if args['quiet']:
-    logger.setLevel(logging.WARNING)
-if args['verbose']:
-    logger.setLevel(logging.DEBUG)
 
-file_format = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
-stream_format = logging.Formatter('%(levelname)s:%(message)s')
+def configure_logger(args: dict) -> None:
+    """Configure logging using already parsed arguments."""
 
-file_handler = logging.FileHandler('debug.log', encoding="utf-16")
-file_handler.setFormatter(file_format)
+    # Remove any existing handlers to avoid duplicate logs when reconfigured
+    logger.handlers.clear()
 
-stream_handler = logging.StreamHandler()
-stream_handler.setFormatter(stream_format)
+    if args.get('verbose'):
+        # clear log file
+        with open('debug.log', 'w'):
+            pass
 
-if args['verbose']:
-    logger.addHandler(file_handler)
-logger.addHandler(stream_handler)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    logger.setLevel(logging.INFO)
+    if args.get('quiet'):
+        logger.setLevel(logging.WARNING)
+    if args.get('verbose'):
+        logger.setLevel(logging.DEBUG)
+
+    file_format = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
+    stream_format = logging.Formatter('%(levelname)s:%(message)s')
+
+    if args.get('verbose'):
+        file_handler = logging.FileHandler('debug.log', encoding="utf-16")
+        file_handler.setFormatter(file_format)
+        logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(stream_format)
+    logger.addHandler(stream_handler)

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from io import BytesIO
 import json
 
 from .args import get_args
-from .logger import logger
+from .logger import logger, configure_logger
 from .version import __version__
 from .helper import get_file_hash, print_download_bar, check_date, parse_url, compile_post_path, compile_file_path
 from .my_yt_dlp import my_yt_dlp
@@ -716,4 +716,6 @@ class downloader:
 
 
 def main():
-    downloader(get_args())
+    args = get_args()
+    configure_logger(args)
+    downloader(args)


### PR DESCRIPTION
## Summary
- expose a `configure_logger` function to set up logging
- call `configure_logger` in `main` after parsing arguments

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
import src.logger as l
l.configure_logger({'verbose': False, 'quiet': False})
print('configured')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685ce46ce6008325bc82caea81506358